### PR TITLE
Allow identity/null conversion

### DIFF
--- a/coastalmodeling_vdatum/vdatum.py
+++ b/coastalmodeling_vdatum/vdatum.py
@@ -295,8 +295,12 @@ def convert(vd_from: str,
         raise ValueError(f"{vd_from} or {vd_to} is not a valid. \
         Please use one of the following: 'xgeoid20b','navd88','mllw','mlw','mhw','lmsl','sgeoid2022'")
 
-    h_g,g_g,g_h=inputs(vd_from,vd_to)
-    clat,clon,cz=build_pipe(lat, lon ,z ,h_g , g_g, g_h, online, epoch=epoch)
+    if vd_from == vd_to:
+        _logger.info(f'Identity datum conversion from {vd_from} to {vd_to} requested. Returning input values.')
+        clat, clon, cz = lat, lon, z
+    else:
+        h_g,g_g,g_h=inputs(vd_from,vd_to)
+        clat,clon,cz=build_pipe(lat, lon ,z ,h_g , g_g, g_h, online, epoch=epoch)
 
     return clat,clon,cz
 

--- a/tests/test_online_vdatum.py
+++ b/tests/test_online_vdatum.py
@@ -21,7 +21,8 @@ def main():
     tests = [
         {'vfrom':'lmsl', 'vto':'mlw', 'lat':30.197168, 'lon':-87.842459, 'result':0.183},
         {'vfrom':'lmsl', 'vto':'mllw', 'lat':30.197168, 'lon':-87.842459, 'result':0.198},
-        {'vfrom':'lmsl', 'vto':'mhw', 'lat':30.197168, 'lon':-87.842459, 'result':-0.187}
+        {'vfrom':'lmsl', 'vto':'mhw', 'lat':30.197168, 'lon':-87.842459, 'result':-0.187},
+        {'vfrom':'lmsl', 'vto':'lmsl', 'lat':30.197168, 'lon':-87.842459, 'result':0.0}
     ]
     
     for t in tests:


### PR DESCRIPTION
Previously, `vdatum.convert` failed if used with identical source and destination datums, for example, from NAVD88 to NAVD88.

This PR brings in code that allows this by simply returning the input lat, lon and z parameters. 

This case is also added to the basic tests.